### PR TITLE
Fix LCRQ dequeue return type being `int` instead of `sval_t`

### DIFF
--- a/src/dcbo-lcrq/lcrq.c
+++ b/src/dcbo-lcrq/lcrq.c
@@ -354,9 +354,9 @@ int enqueue_wrap(queue_t *q, handle_t *th, sval_t v) {
   return 1;
 }
 
-int dequeue_wrap(queue_t *q, handle_t *th) {
+sval_t dequeue_wrap(queue_t *q, handle_t *th) {
   int64_t val = (int64_t) dequeue_(q, th);
-  if (val != -1) return val;
+  if (val != -1) return (sval_t) val;
   return 0;
 }
 

--- a/src/dcbo-lcrq/partial-queue.h
+++ b/src/dcbo-lcrq/partial-queue.h
@@ -26,13 +26,11 @@ extern __thread handle_t lcrq_handle;
 
 // Expose functions
 int enqueue_wrap(queue_t *q, handle_t *th, sval_t v);
-int dequeue_wrap(queue_t *q, handle_t *th);
+sval_t dequeue_wrap(queue_t *q, handle_t *th);
 uint64_t lcrq_queue_size(queue_t *q);
 uint64_t lcrq_enq_count(queue_t *q);
 uint64_t lcrq_deq_count(queue_t *q);
 uint64_t lcrq_tail_version(queue_t *q);
-
-int dequeue_wrap(queue_t *q, handle_t *th);
 
 /* End of interface */
 

--- a/src/lcrq/lcrq.c
+++ b/src/lcrq/lcrq.c
@@ -365,9 +365,9 @@ int enqueue_wrap(queue_t *q, sval_t v) {
   return 1;
 }
 
-int dequeue_wrap(queue_t *q) {
+sval_t dequeue_wrap(queue_t *q) {
   int64_t val = (int64_t) dequeue_(q, &thread_handle);
-  if (val != -1) return val;
+  if (val != -1) return (sval_t) val;
   return 0;
 }
 

--- a/src/lcrq/queue.h
+++ b/src/lcrq/queue.h
@@ -25,7 +25,7 @@ extern __thread handle_t handle;
 
 // Expose functions
 int enqueue_wrap(queue_t *q, sval_t v);
-int dequeue_wrap(queue_t *q);
+sval_t dequeue_wrap(queue_t *q);
 uint64_t lcrq_queue_size(queue_t *q);
 uint64_t lcrq_enq_count(queue_t *q);
 uint64_t lcrq_deq_count(queue_t *q);

--- a/src/simple-dcbo-lcrq/lcrq.c
+++ b/src/simple-dcbo-lcrq/lcrq.c
@@ -350,9 +350,9 @@ int enqueue_wrap(queue_t *q, handle_t *th, sval_t v) {
   return 1;
 }
 
-int dequeue_wrap(queue_t *q, handle_t *th) {
+sval_t dequeue_wrap(queue_t *q, handle_t *th) {
   int64_t val = (int64_t) dequeue_(q, th);
-  if (val != -1) return val;
+  if (val != -1) return (sval_t) val;
   return 0;
 }
 

--- a/src/simple-dcbo-lcrq/queue.h
+++ b/src/simple-dcbo-lcrq/queue.h
@@ -22,13 +22,11 @@ extern __thread handle_t handle;
 
 // Expose functions
 int enqueue_wrap(queue_t *q, handle_t *th, sval_t v);
-int dequeue_wrap(queue_t *q, handle_t *th);
+sval_t dequeue_wrap(queue_t *q, handle_t *th);
 uint64_t lcrq_queue_size(queue_t *q);
 uint64_t lcrq_enq_count(queue_t *q);
 uint64_t lcrq_deq_count(queue_t *q);
 uint64_t lcrq_tail_version(queue_t *q);
-
-int dequeue_wrap(queue_t *q, handle_t *th);
 
 /* End of interface */
 


### PR DESCRIPTION
Currently, 64-bit values enqueued to the d-CBO-LCRQ are truncated to 32 bits on dequeue because the LCRQ uses `int` instead of `sval_t` in its dequeue return type.